### PR TITLE
minor typos

### DIFF
--- a/doc/softwareGuide/softwareGuide.tex
+++ b/doc/softwareGuide/softwareGuide.tex
@@ -114,7 +114,7 @@ It opens the Poppy Humanoid web interface, which allows you to:
 You may wish to install the Poppy development tool on your computer for several reasons:
 
 \begin{itemize}
-\item you have want to use a simulator
+\item you want to use a simulator
 \item you want to control a Poppy creature directly plugged on your computer
 \item You do lots of development and want an environment friendlier than a webservice or SSH.
 \end{itemize}
@@ -157,7 +157,7 @@ For the poppy-humanoid sources, follow the same procedure:
 
 \begin{verbatim}
 git clone --recursive https://github.com/poppy-project/poppy-humanoid.git
-cd ppoppy-humanoid/software
+cd poppy-humanoid/software
 python setup.py build
 python setup.py install
 \end{verbatim}


### PR DESCRIPTION
minor typos in the installation process.

side note: 
copy/paste of python sample code may fail from pdf version as ' is converted to `
an example is line 204 (chap 4.2)
  poppy = PoppyHumanoid(simulator=’vrep’)
which become in pdf
  poppy = PoppyHumanoid(simulator=`vrep`) 
